### PR TITLE
Please use UTF-8 by default.

### DIFF
--- a/git2cl
+++ b/git2cl
@@ -72,6 +72,7 @@ use strict;
 use POSIX qw(strftime);
 use Text::Wrap qw(wrap);
 use FileHandle;
+use open qw/:std :utf8/;
 
 use constant EMPTY_LOG_MESSAGE => '*** empty log message ***';
 


### PR DESCRIPTION
There's basically no system out there that defaults to anything else. This includes git's commit logs.

Thus, just default to UTF-8.